### PR TITLE
Set dmFields to change width and height

### DIFF
--- a/SetResolution/DisplayManager.cs
+++ b/SetResolution/DisplayManager.cs
@@ -16,7 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-
+using static Westwind.SetResolution.DisplayManagerNative;
 
 namespace Westwind.SetResolution
 {
@@ -49,7 +49,8 @@ namespace Westwind.SetResolution
             mode.dmDisplayOrientation = (uint)set.Orientation;
             mode.dmBitsPerPel = (uint)set.BitCount;
             mode.dmDisplayFrequency = (uint)set.Frequency;
-           
+            mode.dmFields = DmFlags.DM_PELSWIDTH | DmFlags.DM_PELSHEIGHT;
+
             DisplayChangeResult result = (DisplayChangeResult)DisplayManagerNative.ChangeDisplaySettingsEx(deviceName, ref mode, IntPtr.Zero,  0, IntPtr.Zero);
             
             string msg = null;

--- a/SetResolution/DisplayManagerNative.cs
+++ b/SetResolution/DisplayManagerNative.cs
@@ -40,6 +40,41 @@ namespace Westwind.SetResolution
         public const int DMDO_180 = 2;
         public const int DMDO_270 = 3;
 
+        [Flags()]
+        public enum DmFlags : int
+        {
+            DM_ORIENTATION = 0x00000001,
+            DM_PAPERSIZE = 0x00000002,
+            DM_PAPERLENGTH = 0x00000004,
+            DM_PAPERWIDTH = 0x00000008,
+            DM_SCALE = 0x00000010,
+            DM_POSITION = 0x00000020,
+            DM_NUP = 0x00000040,
+            DM_DISPLAYORIENTATION = 0x00000080,
+            DM_COPIES = 0x00000100,
+            DM_DEFAULTSOURCE = 0x00000200,
+            DM_PRINTQUALITY = 0x00000400,
+            DM_COLOR = 0x00000800,
+            DM_DUPLEX = 0x00001000,
+            DM_YRESOLUTION = 0x00002000,
+            DM_TTOPTION = 0x00004000,
+            DM_COLLATE = 0x00008000,
+            DM_FORMNAME = 0x00010000,
+            DM_LOGPIXELS = 0x00020000,
+            DM_BITSPERPEL = 0x00040000,
+            DM_PELSWIDTH = 0x00080000,
+            DM_PELSHEIGHT = 0x00100000,
+            DM_DISPLAYFLAGS = 0x00200000,
+            DM_DISPLAYFREQUENCY = 0x00400000,
+            DM_ICMMETHOD = 0x00800000,
+            DM_ICMINTENT = 0x01000000,
+            DM_MEDIATYPE = 0x02000000,
+            DM_DITHERTYPE = 0x04000000,
+            DM_PANNINGWIDTH = 0x08000000,
+            DM_PANNINGHEIGHT = 0x10000000,
+            DM_DISPLAYFIXEDOUTPUT = 0x20000000
+        }
+
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
         public struct DEVMODE
         {
@@ -68,7 +103,7 @@ namespace Westwind.SetResolution
             public ushort dmDriverExtra;
 
             [MarshalAs(UnmanagedType.U4)]
-            public uint dmFields;
+            public DmFlags dmFields;
 
             public POINTL dmPosition;
 


### PR DESCRIPTION
When trying to set my monitor layout to the max settings ( 3440x1440 32bits 120hz ) `DisplayManagerNative.ChangeDisplaySettingsEx` returns BadMode:
![image](https://user-images.githubusercontent.com/40184418/224492324-411e9cb1-8893-48ec-b78f-af236b2440d5.png).

### SetResolution.xml:
```
<?xml version="1.0" encoding="utf-8"?>
<SetResolution xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Profiles>
      <DisplayProfile>
         <Name>Game</Name>
         <Width>1920</Width>
         <Height>1080</Height>
         <Frequency>165</Frequency>
         <BitSize>32</BitSize>
         <Orientation>Default</Orientation>
      </DisplayProfile>
      <DisplayProfile>
         <Name>Game2</Name>
         <Width>1920</Width>
         <Height>1080</Height>
         <Frequency>144</Frequency>
         <BitSize>32</BitSize>
         <Orientation>Default</Orientation>
      </DisplayProfile>
      <DisplayProfile>
         <Name>Normal</Name>
         <Width>3440</Width>
         <Height>1440</Height>
         <Frequency>120</Frequency>
         <BitSize>32</BitSize>
         <Orientation>Default</Orientation>
      </DisplayProfile>
   </Profiles>
   <MinResolutionWidth>1024</MinResolutionWidth>
</SetResolution>
```

I digged a bit in stackoverflow and I found this fix that worked here.
I don't have any experience with this kind of library, but it fixed for me locally 😄 
Hope it works for everyone.

Great tool btw!